### PR TITLE
Be able to set and api_key different than the global one

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,4 @@ tags
 *.swp
 *.un~
 .byebug_history
+.gs

--- a/lib/conekta/conekta_object.rb
+++ b/lib/conekta/conekta_object.rb
@@ -78,7 +78,13 @@ module Conekta
       end
     end
 
+    def set_api_key(_api_key)
+      @api_key ||= _api_key
+    end
+
     protected
+
+    attr_reader :api_key
 
     def to_hash
       hash = Hash.new

--- a/lib/conekta/customer.rb
+++ b/lib/conekta/customer.rb
@@ -73,6 +73,7 @@ module Conekta
       submodels.each do |submodel|
         self.send(submodel).each do |k, v|
           v.create_attr('customer', customer)
+          v.set_api_key(api_key) if api_key
 
           self.send(submodel).set_val(k,v)
         end if self.respond_to?(submodel) && !self.send(submodel).nil?

--- a/lib/conekta/list.rb
+++ b/lib/conekta/list.rb
@@ -52,7 +52,7 @@ module Conekta
     def move_cursor(limit)
       @params["limit"] = limit if !limit.nil? && !limit.to_s.empty?
       _url = Util.types[@elements_type.downcase]._url
-      response = Requestor.new.request(:get, _url, @params)
+      response = Requestor.new(api_key).request(:get, _url, @params)
       self.load_from(response)
     end
   end

--- a/lib/conekta/operations/create.rb
+++ b/lib/conekta/operations/create.rb
@@ -2,10 +2,11 @@ module Conekta
   module Operations
     module Create
       module ClassMethods
-        def create(params)
+        def create(params, _api_key = nil)
           _url = Util.types[self.class_name.downcase]._url
-          response = Requestor.new.request(:post, _url, params)
+          response = Requestor.new(_api_key).request(:post, _url, params)
           instance = self.new
+          instance.set_api_key(_api_key) if _api_key
           instance.load_from(response)
           instance
         end

--- a/lib/conekta/operations/create_member.rb
+++ b/lib/conekta/operations/create_member.rb
@@ -1,10 +1,10 @@
 module Conekta
   module Operations
     module CreateMember
-      def create_member(member, params)
+      def create_member(member, params, _api_key = nil)
         _url     = [self._url, member].join('/')
         member   = member.to_sym
-        response = Requestor.new.request(:post, _url, params)
+        response = Requestor.new(_api_key).request(:post, _url, params)
 
         if self.send(member) &&
            (self.send(member).class.class_name == "ConektaObject" ||

--- a/lib/conekta/operations/custom_action.rb
+++ b/lib/conekta/operations/custom_action.rb
@@ -3,7 +3,7 @@ module Conekta
     module CustomAction
       def custom_action(method, action=nil, params=nil)
         _url     = action ? [self._url, action].join('/') : self._url
-        response = Requestor.new.request(method, _url, params)
+        response = Requestor.new(api_key).request(method, _url, params)
 
         self.load_from(response)
         self

--- a/lib/conekta/operations/find.rb
+++ b/lib/conekta/operations/find.rb
@@ -2,9 +2,10 @@ module Conekta
   module Operations
     module Find
       module ClassMethods
-        def find(id)
+        def find(id, _api_key = nil)
           instance = self.new(id)
-          response = Requestor.new.request(:get, instance._url)
+          instance.set_api_key(_api_key) if _api_key
+          response = Requestor.new(_api_key).request(:get, instance._url)
           instance.load_from(response)
           instance
         end

--- a/lib/conekta/operations/update.rb
+++ b/lib/conekta/operations/update.rb
@@ -2,7 +2,7 @@ module Conekta
   module Operations
     module Update
       def update(params)
-        response = Requestor.new.request(:put, self._url, params)
+        response = Requestor.new(api_key).request(:put, self._url, params)
         self.load_from(response)
         self
       end

--- a/lib/conekta/operations/where.rb
+++ b/lib/conekta/operations/where.rb
@@ -11,10 +11,11 @@ module Conekta
       end
 
       module ClassMethods
-        def where(params=nil)
+        def where(params = nil, _api_key = nil)
           _url = Util.types[self.class_name.downcase]._url
-          response = Requestor.new.request(:get, _url, params)
+          response = Requestor.new(_api_key).request(:get, _url, params)
           instance = ::Conekta::Operations::Where.handle_type_of_paging(response, self.class_name, params)
+          instance.set_api_key(_api_key) if _api_key
           instance.load_from(response)
           instance
         end

--- a/lib/conekta/order.rb
+++ b/lib/conekta/order.rb
@@ -50,7 +50,7 @@ module Conekta
     end
 
     def create_charge(params)
-      self.create_member('charges', params)
+      self.create_member('charges', params, api_key)
     end
 
     def create_shipping_contact(params)
@@ -76,6 +76,7 @@ module Conekta
       submodels.each do |submodel|
         self.send(submodel).each do |k, v|
           v.create_attr('order', order)
+          v.set_api_key(api_key) if api_key
 
           self.send(submodel).set_val(k,v)
         end if self.respond_to?(submodel) && !self.send(submodel).nil?

--- a/lib/conekta/payee.rb
+++ b/lib/conekta/payee.rb
@@ -35,12 +35,12 @@ module Conekta
 
     def create_payout_method(params)
       raise_version_error("1.0.0") if Conekta.api_version > "1.0.0"
-      self.create_member('payout_methods', params)
+      self.create_member('payout_methods', params, api_key)
     end
 
     def create_destination(params)
       raise_version_error("2.0.0") if Conekta.api_version <= "1.0.0"
-      self.create_member('destinations', params)
+      self.create_member('destinations', params, api_key)
     end
 
     private

--- a/lib/conekta/requestor.rb
+++ b/lib/conekta/requestor.rb
@@ -8,8 +8,8 @@ module Conekta
 
     attr_reader :api_key
 
-    def initialize
-      @api_key = Conekta.api_key
+    def initialize(_api_key = nil)
+      @api_key = _api_key || Conekta.api_key
     end
 
     def api_url(_url='')

--- a/lib/conekta/resource.rb
+++ b/lib/conekta/resource.rb
@@ -24,8 +24,10 @@ module Conekta
 
     def create_member_with_relation(member, params, parent)
       parent_klass = parent.class.underscored_class
-      child = self.create_member(member, params)
+      api_key = parent.api_key if parent.api_key
+      child = self.create_member(member, params, api_key)
       child.create_attr(parent_klass.to_s, parent)
+      child.set_api_key(api_key) if api_key
       return child
     end
 

--- a/spec/conekta/2.0.0/customer_spec.rb
+++ b/spec/conekta/2.0.0/customer_spec.rb
@@ -48,29 +48,62 @@ describe Conekta::Customer do
         }
       end
 
-      it "successfully creates source for customer" do
-        customer = Conekta::Customer.create(customer_oxxo)
-        source = customer.payment_sources.first
+      context "with global api_key" do
+        it "successfully creates source for customer" do
+          customer = Conekta::Customer.create(customer_oxxo)
+          source = customer.payment_sources.first
 
-        expect(source.class.to_s).to eq('Conekta::PaymentSource')
-        expect(customer.payment_sources.class.to_s).to eq('Conekta::List')
-        expect(source.reference.size).to eq(14)
+          expect(source.class.to_s).to eq('Conekta::PaymentSource')
+          expect(customer.payment_sources.class.to_s).to eq('Conekta::List')
+          expect(source.reference.size).to eq(14)
+        end
+
+        it 'successfully creates oxxo recurrent reference for customer' do
+          source = customer.create_offline_recurrent_reference(oxxo_source_params)
+
+          expect(source.class.to_s).to eq("Conekta::PaymentSource")
+          expect(customer.payment_sources.class.to_s).to eq("Conekta::List")
+          expect(source.reference.size).to eq(14)
+        end
+
+        it "successfully creates shipping contact for customer" do
+          shipping_contact =
+            customer.create_shipping_contact(shipping_contact_params)
+
+          expect(shipping_contact.class.to_s).to eq("Conekta::ShippingContact")
+          expect(customer.shipping_contacts.class.to_s).to eq("Conekta::List")
+        end
       end
 
-      it 'successfully creates oxxo recurrent reference for customer' do
-        source = customer.create_offline_recurrent_reference(oxxo_source_params)
+      context "with local api_key" do
+        include_context "local api_key"
 
-        expect(source.class.to_s).to eq("Conekta::PaymentSource")
-        expect(customer.payment_sources.class.to_s).to eq("Conekta::List")
-        expect(source.reference.size).to eq(14)
-      end
+        let(:customer) { Conekta::Customer.create(customer_data, local_api_key) }
 
-      it "successfully creates shipping contact for customer" do
-        shipping_contact =
-          customer.create_shipping_contact(shipping_contact_params)
+        it "successfully creates source for customer" do
+          customer = Conekta::Customer.create(customer_oxxo, local_api_key)
+          source = customer.payment_sources.first
 
-        expect(shipping_contact.class.to_s).to eq("Conekta::ShippingContact")
-        expect(customer.shipping_contacts.class.to_s).to eq("Conekta::List")
+          expect(source.class.to_s).to eq('Conekta::PaymentSource')
+          expect(customer.payment_sources.class.to_s).to eq('Conekta::List')
+          expect(source.reference.size).to eq(14)
+        end
+
+        it 'successfully creates oxxo recurrent reference for customer' do
+          source = customer.create_offline_recurrent_reference(oxxo_source_params)
+
+          expect(source.class.to_s).to eq("Conekta::PaymentSource")
+          expect(customer.payment_sources.class.to_s).to eq("Conekta::List")
+          expect(source.reference.size).to eq(14)
+        end
+
+        it "successfully creates shipping contact for customer" do
+          shipping_contact =
+            customer.create_shipping_contact(shipping_contact_params)
+
+          expect(shipping_contact.class.to_s).to eq("Conekta::ShippingContact")
+          expect(customer.shipping_contacts.class.to_s).to eq("Conekta::List")
+        end
       end
     end
   end

--- a/spec/conekta/2.0.0/discount_line_spec.rb
+++ b/spec/conekta/2.0.0/discount_line_spec.rb
@@ -25,25 +25,57 @@ describe Conekta::DiscountLine do
 
   let(:discount_line) { order.discount_lines.first }
 
-  context "deleting discount lines" do
-    it "successful discount line delete" do
-      discount_line.delete
+  context "with global api_key" do
+    context "deleting discount lines" do
+      it "successful discount line delete" do
+        discount_line.delete
 
-      expect(discount_line.deleted).to eq(true)
+        expect(discount_line.deleted).to eq(true)
+      end
+    end
+
+    context "updating discount lines" do
+      it "successful discount line update" do
+        discount_line.update(amount: 11)
+
+        expect(discount_line.amount).to eq(11)
+      end
+
+      it "unsuccessful discount line update" do
+        expect {
+          discount_line.update(amount: -1)
+        }.to raise_error(Conekta::ParameterValidationError)
+      end
     end
   end
 
-  context "updating discount lines" do
-    it "successful discount line update" do
-      discount_line.update(amount: 11)
+  context "with local api_key" do
+    include_context "local api_key"
 
-      expect(discount_line.amount).to eq(11)
+    let(:order) do
+      Conekta::Order.create(order_data.merge(discount_lines: discount_lines), local_api_key)
     end
 
-    it "unsuccessful discount line update" do
-      expect {
-        discount_line.update(amount: -1)
-      }.to raise_error(Conekta::ParameterValidationError)
+    context "deleting discount lines" do
+      it "successful discount line delete" do
+        discount_line.delete
+
+        expect(discount_line.deleted).to eq(true)
+      end
+    end
+
+    context "updating discount lines" do
+      it "successful discount line update" do
+        discount_line.update(amount: 11)
+
+        expect(discount_line.amount).to eq(11)
+      end
+
+      it "unsuccessful discount line update" do
+        expect {
+          discount_line.update(amount: -1)
+        }.to raise_error(Conekta::ParameterValidationError)
+      end
     end
   end
 end

--- a/spec/conekta/2.0.0/error_spec.rb
+++ b/spec/conekta/2.0.0/error_spec.rb
@@ -24,7 +24,7 @@ describe Conekta::Error do
   end
 
   it "test api error" do
-    expect{ 
+    expect{
       Conekta::Customer.create({
         cards: {
           0 => "tok_test_visa_4242"

--- a/spec/conekta/2.0.0/line_item_spec.rb
+++ b/spec/conekta/2.0.0/line_item_spec.rb
@@ -28,25 +28,55 @@ describe Conekta::LineItem do
   let(:order)     { Conekta::Order.create(order_data) }
   let(:line_item) { order.line_items.first }
 
-  context "deleting line items" do
-    it "successful line item delete" do
-      line_item.delete
+  context "with global api_key" do
+    context "deleting line items" do
+      it "successful line item delete" do
+        line_item.delete
 
-      expect(line_item.deleted).to eq(true)
+        expect(line_item.deleted).to eq(true)
+      end
+    end
+
+    context "updating line items" do
+      it "successful line item update" do
+        line_item.update(unit_price: 1000)
+
+        expect(line_item.unit_price).to eq(1000)
+      end
+
+      it "unsuccessful line item update" do
+        expect {
+          line_item.update(description: nil)
+        }.to raise_error(Conekta::ParameterValidationError)
+      end
     end
   end
 
-  context "updating line items" do
-    it "successful line item update" do
-      line_item.update(unit_price: 1000)
+  context "with local api_key" do
+    include_context "local api_key"
 
-      expect(line_item.unit_price).to eq(1000)
+    let(:order) { Conekta::Order.create(order_data, local_api_key) }
+
+    context "deleting line items" do
+      it "successful line item delete" do
+        line_item.delete
+
+        expect(line_item.deleted).to eq(true)
+      end
     end
 
-    it "unsuccessful line item update" do
-      expect {
-        line_item.update(description: nil)
-      }.to raise_error(Conekta::ParameterValidationError)
+    context "updating line items" do
+      it "successful line item update" do
+        line_item.update(unit_price: 1000)
+
+        expect(line_item.unit_price).to eq(1000)
+      end
+
+      it "unsuccessful line item update" do
+        expect {
+          line_item.update(description: nil)
+        }.to raise_error(Conekta::ParameterValidationError)
+      end
     end
   end
 

--- a/spec/conekta/2.0.0/list_spec.rb
+++ b/spec/conekta/2.0.0/list_spec.rb
@@ -11,19 +11,49 @@ describe Conekta::List do
     order_list
   end
 
-  context "moving cursor" do
-    it "moves cursor forward" do
-      window = Conekta::Order.where({"limit" => 5, "next" => list[9].id})
-      expect(window.first.id).to eq(list[10].id)
-      window.next(limit: 1)
-      expect(window.first.id).to eq(list[15].id)
+  context "with global api_key" do
+    context "moving cursor" do
+      it "moves cursor forward" do
+        window = Conekta::Order.where({"limit" => 5, "next" => list[9].id})
+        expect(window.first.id).to eq(list[10].id)
+        window.next(limit: 1)
+        expect(window.first.id).to eq(list[15].id)
+      end
+
+      it "moves cursor backwards" do
+        window = Conekta::Order.where({"limit" => 5, "next" => list[14].id})
+        expect(window.first.id).to eq(list[15].id)
+        window.previous(limit: 1)
+        expect(window.first.id).to eq(list[14].id)
+      end
+    end
+  end
+
+  context "with local api_key" do
+    include_context "local api_key"
+
+    let(:list) do
+      response = JSON.parse(File.read("spec/support/fixtures/orders.json"))
+      order_list = Conekta::List.new("Order", response)
+      order_list.set_api_key(global_api_key)
+      order_list.load_from(response)
+      order_list
     end
 
-    it "moves cursor backwards" do
-      window = Conekta::Order.where({"limit" => 5, "next" => list[14].id})
-      expect(window.first.id).to eq(list[15].id)
-      window.previous(limit: 1)
-      expect(window.first.id).to eq(list[14].id)
+    context "moving cursor" do
+      it "moves cursor forward" do
+        window = Conekta::Order.where({"limit" => 5, "next" => list[9].id}, global_api_key)
+        expect(window.first.id).to eq(list[10].id)
+        window.next(limit: 1)
+        expect(window.first.id).to eq(list[15].id)
+      end
+
+      it "moves cursor backwards" do
+        window = Conekta::Order.where({"limit" => 5, "next" => list[14].id}, global_api_key)
+        expect(window.first.id).to eq(list[15].id)
+        window.previous(limit: 1)
+        expect(window.first.id).to eq(list[14].id)
+      end
     end
   end
 end

--- a/spec/conekta/2.0.0/order_spec.rb
+++ b/spec/conekta/2.0.0/order_spec.rb
@@ -67,225 +67,453 @@ describe Conekta::Order do
     order_data.merge(charges: card_charges)
   end
 
-  context "creating orders" do
-    it "successful order create" do
-      order = Conekta::Order.create(order_data)
-
-      expect(order).to be_a(Conekta::Order)
-      expect(order.metadata["test"]).to eq(true)
-    end
-
-    it "unsuccessful order create" do
-      expect{
-        Conekta::Order.create({})
-      }.to raise_error(Conekta::ParameterValidationError)
-    end
-
-    context "with charges" do
+  context "with global api_key" do
+    context "creating orders" do
       it "successful order create" do
-        order = Conekta::Order.create(order_data_with_charges.
-                                      merge(customer_info: customer_info))
+        order = Conekta::Order.create(order_data)
+
+        expect(order).to be_a(Conekta::Order)
+        expect(order.metadata["test"]).to eq(true)
+      end
+
+      it "unsuccessful order create" do
+        expect{
+          Conekta::Order.create({})
+        }.to raise_error(Conekta::ParameterValidationError)
+      end
+
+      context "with charges" do
+        it "successful order create" do
+          order = Conekta::Order.create(order_data_with_charges.
+                                        merge(customer_info: customer_info))
+
+          expect(order).to be_a(Conekta::Order)
+        end
+
+        context "unsuccessful order create" do
+          it "with missing customer_info and customer_id" do
+            expect{
+              Conekta::Order.create(order_data_with_charges)
+            }.to raise_error(Conekta::ParameterValidationError)
+          end
+        end
+      end
+    end
+
+    context "updating orders" do
+      let(:order) { Conekta::Order.create(order_data) }
+
+      it "successful order update" do
+        order.update(charges: charges, customer_info: customer_info)
+
+        expect(order.charges).not_to be_empty
+      end
+
+      it "unsuccessful order update" do
+        expect{
+          order.update(charges: charges)
+        }.to raise_error(Conekta::ParameterValidationError)
+      end
+    end
+
+    context "creating submodels" do
+      let(:line_item_params) do
+        {
+          name: "Box of Cohiba S1s",
+          description: "Imported From Mex.",
+          unit_price: 35000,
+          quantity: 1,
+          tags: ["food", "mexican food"]
+        }
+      end
+
+      let(:tax_line_params) do
+        {
+          description: "IVA",
+          amount:      600
+        }
+      end
+
+      let(:shipping_line_params) do
+        {
+          description:     "Otro Shipping",
+          amount:          40,
+          tracking_number: "TRACK124",
+          carrier:         "USPS",
+          method:          "Train",
+        }
+      end
+
+      let(:discount_line_params) do
+        {
+          code: "Cupon de descuento",
+          type:        "loyalty",
+          amount:      10
+        }
+      end
+
+      let(:charge_params) do
+        {
+          payment_method: {
+            type: "oxxo_cash",
+            expires_at: (Time.now + 3600).to_i
+          },
+          amount: 35000
+        }
+      end
+
+      let(:shipping_contact_params) do
+        {
+          id: "1jap4jmcjnwh34",
+          email: "thomas.logan@xmen.org",
+          phone: "+5213353319758",
+          receiver: "Marvin Fuller",
+          between_streets: "Ackerman Crescent",
+          address: {
+            street1: "250 Alexis St",
+            city: "Red Deer",
+            state: "Alberta",
+            country: "MX",
+            postal_code: "78219",
+            residential: true
+          }
+        }
+      end
+
+      let(:order) { Conekta::Order.create(order_data) }
+
+      it "successfully creates charge for order" do
+        other_params = {
+          currency: 'mxn',
+          customer_info: {
+            name: 'John Constantine',
+            phone: '+5213353319758',
+            email: 'hola@hola.com'
+          }
+        }
+
+        order  = Conekta::Order.create(order_data.merge(other_params))
+        charge = order.create_charge(charge_params)
+
+        expect(charge.class.to_s).to eq("Conekta::Charge")
+        expect(order.charges.class.to_s).to eq("Conekta::List")
+      end
+
+      it "successfully creates line item for order" do
+        line_item = order.create_line_item(line_item_params)
+
+        expect(line_item.class.to_s).to eq("Conekta::LineItem")
+        expect(order.line_items.class.to_s).to eq("Conekta::List")
+      end
+
+      it "successfully creates tax line for order" do
+        tax_line     = order.create_tax_line(tax_line_params)
+        new_tax_line = order.create_tax_line(description: "ISR", amount: 2)
+
+        expect(tax_line.class.to_s).to eq("Conekta::TaxLine")
+        expect(order.tax_lines.class.to_s).to eq("Conekta::List")
+        expect(order.tax_lines.total).to eq(2)
+      end
+
+      it "successfully creates shipping line for order" do
+        shipping_line = order.create_shipping_line(shipping_line_params)
+
+        expect(shipping_line.class.to_s).to eq("Conekta::ShippingLine")
+        expect(order.shipping_lines.class.to_s).to eq("Conekta::List")
+      end
+
+      it "successfully creates discount line for order" do
+        discount_line = order.create_discount_line(discount_line_params)
+
+        discount_line.update({amount: 1000})
+
+        expect(discount_line.class.to_s).to eq("Conekta::DiscountLine")
+        expect(order.discount_lines.class.to_s).to eq("Conekta::List")
+      end
+
+      it "successfully create shipping contact for order" do
+        shipping_contact = order.create_shipping_contact(shipping_contact_params)
+
+        expect(shipping_contact.class.to_s).to eq("Conekta::ShippingContact")
+      end
+    end
+
+    context "get" do
+      it "successfully gets order" do
+        id = Conekta::Order.create(order_data).id
+
+        order = Conekta::Order.find(id)
 
         expect(order).to be_a(Conekta::Order)
       end
 
-      context "unsuccessful order create" do
-        it "with missing customer_info and customer_id" do
-          expect{
-            Conekta::Order.create(order_data_with_charges)
-          }.to raise_error(Conekta::ParameterValidationError)
+      it "test successful where" do
+        orders = Conekta::Order.where
+
+        expect(orders).to be_a(Conekta::List)
+        expect(orders.elements_type).to eq("Order")
+        expect(orders.first).to be_a(Conekta::Order)
+      end
+    end
+
+    it "successfully captures an order" do
+      order = Conekta::Order.create(order_data_with_card_charges.
+                                    merge(customer_info: customer_info, pre_authorize: true))
+      expect(order.payment_status).to eq("pre_authorized")
+
+      order.authorize_capture
+
+      expect(order.payment_status).to eq("paid")
+    end
+
+    context "refund" do
+      let(:order_refund) do
+        {
+          amount: 35000,
+          reason: "requested_by_client"
+        }
+      end
+
+      it "test successful refund" do
+        order = Conekta::Order.create(order_data_with_card_charges.
+                                      merge(customer_info: customer_info).
+                                      merge(line_items: line_items))
+        begin
+  				order.refund(order_refund)
+        rescue Exception => e
+  				puts e.details.map{|d| d.message}
+        end
+
+        refunded_order = Conekta::Order.find(order.id)
+
+        expect(refunded_order.payment_status).to eq("refunded")
+      end
+    end
+  end
+
+  context "with local api_key" do
+    include_context "local api_key"
+
+    context "creating orders" do
+      it "successful order create" do
+        order = Conekta::Order.create(order_data, local_api_key)
+
+        expect(order).to be_a(Conekta::Order)
+        expect(order.metadata["test"]).to eq(true)
+      end
+
+      it "unsuccessful order create" do
+        expect{
+          Conekta::Order.create({}, local_api_key)
+        }.to raise_error(Conekta::ParameterValidationError)
+      end
+
+      context "with charges" do
+        it "successful order create" do
+          order = Conekta::Order.create(order_data_with_charges.
+                                        merge(customer_info: customer_info), local_api_key)
+
+          expect(order).to be_a(Conekta::Order)
+        end
+
+        context "unsuccessful order create" do
+          it "with missing customer_info and customer_id" do
+            expect{
+              Conekta::Order.create(order_data_with_charges, local_api_key)
+            }.to raise_error(Conekta::ParameterValidationError)
+          end
         end
       end
     end
-  end
 
-  context "updating orders" do
-    let(:order) { Conekta::Order.create(order_data) }
+    context "updating orders" do
+      let(:order) { Conekta::Order.create(order_data, local_api_key) }
 
-    it "successful order update" do
-      order.update(charges: charges, customer_info: customer_info)
+      it "successful order update" do
+        order.update(charges: charges, customer_info: customer_info)
 
-      expect(order.charges).not_to be_empty
-    end
-
-    it "unsuccessful order update" do
-      expect{
-        order.update(charges: charges)
-      }.to raise_error(Conekta::ParameterValidationError)
-    end
-  end
-
-  context "creating submodels" do
-    let(:line_item_params) do
-      {
-        name: "Box of Cohiba S1s",
-        description: "Imported From Mex.",
-        unit_price: 35000,
-        quantity: 1,
-        tags: ["food", "mexican food"]
-      }
-    end
-
-    let(:tax_line_params) do
-      {
-        description: "IVA",
-        amount:      600
-      }
-    end
-
-    let(:shipping_line_params) do
-      {
-        description:     "Otro Shipping",
-        amount:          40,
-        tracking_number: "TRACK124",
-        carrier:         "USPS",
-        method:          "Train",
-      }
-    end
-
-    let(:discount_line_params) do
-      {
-        code: "Cupon de descuento",
-        type:        "loyalty",
-        amount:      10
-      }
-    end
-
-    let(:charge_params) do
-      {
-        payment_method: {
-          type: "oxxo_cash",
-          expires_at: (Time.now + 3600).to_i
-        },
-        amount: 35000
-      }
-    end
-
-    let(:shipping_contact_params) do
-      {
-        id: "1jap4jmcjnwh34",
-        email: "thomas.logan@xmen.org",
-        phone: "+5213353319758",
-        receiver: "Marvin Fuller",
-        between_streets: "Ackerman Crescent",
-        address: {
-          street1: "250 Alexis St",
-          city: "Red Deer",
-          state: "Alberta",
-          country: "MX",
-          postal_code: "78219",
-          residential: true
-        }
-      }
-    end
-
-    let(:order) { Conekta::Order.create(order_data) }
-
-    it "successfully creates charge for order" do
-      other_params = {
-        currency: 'mxn',
-        customer_info: {
-          name: 'John Constantine',
-          phone: '+5213353319758',
-          email: 'hola@hola.com'
-        }
-      }
-
-      order  = Conekta::Order.create(order_data.merge(other_params))
-      charge = order.create_charge(charge_params)
-
-      expect(charge.class.to_s).to eq("Conekta::Charge")
-      expect(order.charges.class.to_s).to eq("Conekta::List")
-    end
-
-    it "successfully creates line item for order" do
-      line_item = order.create_line_item(line_item_params)
-
-      expect(line_item.class.to_s).to eq("Conekta::LineItem")
-      expect(order.line_items.class.to_s).to eq("Conekta::List")
-    end
-
-    it "successfully creates tax line for order" do
-      tax_line     = order.create_tax_line(tax_line_params)
-      new_tax_line = order.create_tax_line(description: "ISR", amount: 2)
-
-      expect(tax_line.class.to_s).to eq("Conekta::TaxLine")
-      expect(order.tax_lines.class.to_s).to eq("Conekta::List")
-      expect(order.tax_lines.total).to eq(2)
-    end
-
-    it "successfully creates shipping line for order" do
-      shipping_line = order.create_shipping_line(shipping_line_params)
-
-      expect(shipping_line.class.to_s).to eq("Conekta::ShippingLine")
-      expect(order.shipping_lines.class.to_s).to eq("Conekta::List")
-    end
-
-    it "successfully creates discount line for order" do
-      discount_line = order.create_discount_line(discount_line_params)
-
-      discount_line.update({amount: 1000})
-
-      expect(discount_line.class.to_s).to eq("Conekta::DiscountLine")
-      expect(order.discount_lines.class.to_s).to eq("Conekta::List")
-    end
-
-    it "successfully create shipping contact for order" do
-      shipping_contact = order.create_shipping_contact(shipping_contact_params)
-
-      expect(shipping_contact.class.to_s).to eq("Conekta::ShippingContact")
-    end
-  end
-
-  context "get" do
-    it "successfully gets order" do
-      id = Conekta::Order.create(order_data).id
-
-      order = Conekta::Order.find(id)
-
-      expect(order).to be_a(Conekta::Order)
-    end
-
-    it "test successful where" do
-      orders = Conekta::Order.where
-
-      expect(orders).to be_a(Conekta::List)
-      expect(orders.elements_type).to eq("Order")
-      expect(orders.first).to be_a(Conekta::Order)
-    end
-  end
-
-  it "successfully captures an order" do
-    order = Conekta::Order.create(order_data_with_card_charges.
-                                  merge(customer_info: customer_info, pre_authorize: true))
-    expect(order.payment_status).to eq("pre_authorized")
-
-    order.authorize_capture
-
-    expect(order.payment_status).to eq("paid")
-  end
-
-  context "refund" do
-    let(:order_refund) do
-      {
-        amount: 35000,
-        reason: "requested_by_client"
-      }
-    end
-
-    it "test successful refund" do
-      order = Conekta::Order.create(order_data_with_card_charges.
-                                    merge(customer_info: customer_info).
-                                    merge(line_items: line_items))
-      begin
-				order.refund(order_refund)
-      rescue Exception => e
-				puts e.details.map{|d| d.message}
+        expect(order.charges).not_to be_empty
       end
 
-      refunded_order = Conekta::Order.find(order.id)
+      it "unsuccessful order update" do
+        expect{
+          order.update(charges: charges)
+        }.to raise_error(Conekta::ParameterValidationError)
+      end
+    end
 
-      expect(refunded_order.payment_status).to eq("refunded")
+    context "creating submodels" do
+      let(:line_item_params) do
+        {
+          name: "Box of Cohiba S1s",
+          description: "Imported From Mex.",
+          unit_price: 35000,
+          quantity: 1,
+          tags: ["food", "mexican food"]
+        }
+      end
+
+      let(:tax_line_params) do
+        {
+          description: "IVA",
+          amount:      600
+        }
+      end
+
+      let(:shipping_line_params) do
+        {
+          description:     "Otro Shipping",
+          amount:          40,
+          tracking_number: "TRACK124",
+          carrier:         "USPS",
+          method:          "Train",
+        }
+      end
+
+      let(:discount_line_params) do
+        {
+          code: "Cupon de descuento",
+          type:        "loyalty",
+          amount:      10
+        }
+      end
+
+      let(:charge_params) do
+        {
+          payment_method: {
+            type: "oxxo_cash",
+            expires_at: (Time.now + 3600).to_i
+          },
+          amount: 35000
+        }
+      end
+
+      let(:shipping_contact_params) do
+        {
+          id: "1jap4jmcjnwh34",
+          email: "thomas.logan@xmen.org",
+          phone: "+5213353319758",
+          receiver: "Marvin Fuller",
+          between_streets: "Ackerman Crescent",
+          address: {
+            street1: "250 Alexis St",
+            city: "Red Deer",
+            state: "Alberta",
+            country: "MX",
+            postal_code: "78219",
+            residential: true
+          }
+        }
+      end
+
+      let(:order) { Conekta::Order.create(order_data, local_api_key) }
+
+      it "successfully creates charge for order" do
+        other_params = {
+          currency: 'mxn',
+          customer_info: {
+            name: 'John Constantine',
+            phone: '+5213353319758',
+            email: 'hola@hola.com'
+          }
+        }
+
+        order  = Conekta::Order.create(order_data.merge(other_params), local_api_key)
+        charge = order.create_charge(charge_params)
+
+        expect(charge.class.to_s).to eq("Conekta::Charge")
+        expect(order.charges.class.to_s).to eq("Conekta::List")
+      end
+
+      it "successfully creates line item for order" do
+        line_item = order.create_line_item(line_item_params)
+
+        expect(line_item.class.to_s).to eq("Conekta::LineItem")
+        expect(order.line_items.class.to_s).to eq("Conekta::List")
+      end
+
+      it "successfully creates tax line for order" do
+        tax_line     = order.create_tax_line(tax_line_params)
+        new_tax_line = order.create_tax_line(description: "ISR", amount: 2)
+
+        expect(tax_line.class.to_s).to eq("Conekta::TaxLine")
+        expect(order.tax_lines.class.to_s).to eq("Conekta::List")
+        expect(order.tax_lines.total).to eq(2)
+      end
+
+      it "successfully creates shipping line for order" do
+        shipping_line = order.create_shipping_line(shipping_line_params)
+
+        expect(shipping_line.class.to_s).to eq("Conekta::ShippingLine")
+        expect(order.shipping_lines.class.to_s).to eq("Conekta::List")
+      end
+
+      it "successfully creates discount line for order" do
+        discount_line = order.create_discount_line(discount_line_params)
+
+        discount_line.update({amount: 1000})
+
+        expect(discount_line.class.to_s).to eq("Conekta::DiscountLine")
+        expect(order.discount_lines.class.to_s).to eq("Conekta::List")
+      end
+
+      it "successfully create shipping contact for order" do
+        shipping_contact = order.create_shipping_contact(shipping_contact_params)
+
+        expect(shipping_contact.class.to_s).to eq("Conekta::ShippingContact")
+      end
+    end
+
+    context "get" do
+      it "successfully gets order" do
+        id = Conekta::Order.create(order_data, local_api_key).id
+
+        order = Conekta::Order.find(id, local_api_key)
+
+        expect(order).to be_a(Conekta::Order)
+      end
+
+      it "test successful where" do
+        orders = Conekta::Order.where(nil, local_api_key)
+
+        expect(orders).to be_a(Conekta::List)
+        expect(orders.elements_type).to eq("Order")
+        expect(orders.first).to be_a(Conekta::Order)
+      end
+    end
+
+    it "successfully captures an order" do
+      order = Conekta::Order.create(order_data_with_card_charges.
+                                    merge(customer_info: customer_info, pre_authorize: true), local_api_key)
+      expect(order.payment_status).to eq("pre_authorized")
+
+      order.authorize_capture
+
+      expect(order.payment_status).to eq("paid")
+    end
+
+    context "refund" do
+      let(:order_refund) do
+        {
+          amount: 35000,
+          reason: "requested_by_client"
+        }
+      end
+
+      it "test successful refund" do
+        order = Conekta::Order.create(order_data_with_card_charges.
+                                      merge(customer_info: customer_info).
+                                      merge(line_items: line_items), local_api_key)
+        begin
+          order.refund(order_refund)
+        rescue Exception => e
+          puts e.details.map{|d| d.message}
+        end
+
+        refunded_order = Conekta::Order.find(order.id, local_api_key)
+
+        expect(refunded_order.payment_status).to eq("refunded")
+      end
     end
   end
 end

--- a/spec/conekta/2.0.0/payee_spec.rb
+++ b/spec/conekta/2.0.0/payee_spec.rb
@@ -22,33 +22,69 @@ describe Conekta::Payee do
       }
     end
 
-    it 'creates successfully' do
-      payee = Conekta::Payee.create(payee_attributes)
-      expect(payee).to be_a(Conekta::Payee)
+    context "with global api_key" do
+      it 'creates successfully' do
+        payee = Conekta::Payee.create(payee_attributes)
+        expect(payee).to be_a(Conekta::Payee)
+      end
+
+      describe ':payout_methods' do
+        let!(:payee) { Conekta::Payee.create(payee_attributes) }
+        let(:bank_attributes) do
+          {
+            type: "bank_account",
+            account_number: '072225008217746674',
+            account_holder_name: 'J D - Radcorp'
+          }
+        end
+
+        it 'can create payout methods' do
+          payout_method = payee.create_destination(bank_attributes)
+          expect(payout_method).to be_a(Conekta::Destination)
+          # I'm sure this should be a Conekta::PayoutMethod,
+          # just not sure why it's reporting back as a Conekta::Method
+        end
+
+        it 'assigns default_payout_method_id to first payout method created' do
+          payout_method = payee.create_destination(bank_attributes)
+          # refetch the payee object
+          payee = Conekta::Payee.find(payout_method.payee_id)
+          expect(payee.default_destination_id).to eq(payout_method.id)
+        end
+      end
     end
 
-    describe ':payout_methods' do
-      let!(:payee) { Conekta::Payee.create(payee_attributes) }
-      let(:bank_attributes) do
-        {
-          type: "bank_account",
-          account_number: '072225008217746674',
-          account_holder_name: 'J D - Radcorp'
-        }
+    context "with local api_key" do
+      include_context "local api_key"
+
+      it 'creates successfully' do
+        payee = Conekta::Payee.create(payee_attributes, local_api_key)
+        expect(payee).to be_a(Conekta::Payee)
       end
 
-      it 'can create payout methods' do
-        payout_method = payee.create_destination(bank_attributes)
-        expect(payout_method).to be_a(Conekta::Destination)
-        # I'm sure this should be a Conekta::PayoutMethod,
-        # just not sure why it's reporting back as a Conekta::Method
-      end
+      describe ':payout_methods' do
+        let!(:payee) { Conekta::Payee.create(payee_attributes, local_api_key) }
+        let(:bank_attributes) do
+          {
+            type: "bank_account",
+            account_number: '072225008217746674',
+            account_holder_name: 'J D - Radcorp'
+          }
+        end
 
-      it 'assigns default_payout_method_id to first payout method created' do
-        payout_method = payee.create_destination(bank_attributes)
-        # refetch the payee object
-        payee = Conekta::Payee.find(payout_method.payee_id)
-        expect(payee.default_destination_id).to eq(payout_method.id)
+        it 'can create payout methods' do
+          payout_method = payee.create_destination(bank_attributes)
+          expect(payout_method).to be_a(Conekta::Destination)
+          # I'm sure this should be a Conekta::PayoutMethod,
+          # just not sure why it's reporting back as a Conekta::Method
+        end
+
+        it 'assigns default_payout_method_id to first payout method created' do
+          payout_method = payee.create_destination(bank_attributes)
+          # refetch the payee object
+          payee = Conekta::Payee.find(payout_method.payee_id, local_api_key)
+          expect(payee.default_destination_id).to eq(payout_method.id)
+        end
       end
     end
   end

--- a/spec/conekta/2.0.0/shipping_contact_spec.rb
+++ b/spec/conekta/2.0.0/shipping_contact_spec.rb
@@ -34,27 +34,60 @@ describe Conekta::ShippingContact do
                                merge(shipping_contacts: shipping_contacts))
   end
 
- let(:shipping_contact) { customer.shipping_contacts.first }
+  let(:shipping_contact) { customer.shipping_contacts.first }
 
-  context "deleting shipping contacts" do
-    it "successful shipping contact delete" do
-      shipping_contact.delete
+  context "with global api_key" do
+    context "deleting shipping contacts" do
+      it "successful shipping contact delete" do
+        shipping_contact.delete
 
-      expect(shipping_contact.deleted).to eq(true)
+        expect(shipping_contact.deleted).to eq(true)
+      end
+    end
+
+    context "updating shipping contacts" do
+      it "successful shipping contact update" do
+        shipping_contact.update(receiver: "Mario Moreno")
+
+        expect(shipping_contact.receiver).to eq("Mario Moreno")
+      end
+
+      it "unsuccessful shipping contact update" do
+        expect {
+          shipping_contact.update(receiver: 123)
+        }.to raise_error(Conekta::Error)
+      end
     end
   end
 
-  context "updating shipping contacts" do
-    it "successful shipping contact update" do
-      shipping_contact.update(receiver: "Mario Moreno")
+  context "with local api_key" do
+    include_context "local api_key"
 
-      expect(shipping_contact.receiver).to eq("Mario Moreno")
+    let(:customer) do
+      Conekta::Customer.create(customer_data.
+                                 merge(shipping_contacts: shipping_contacts), local_api_key)
     end
 
-    it "unsuccessful shipping contact update" do
-      expect {
-        shipping_contact.update(receiver: 123)
-      }.to raise_error(Conekta::Error)
+    context "deleting shipping contacts" do
+      it "successful shipping contact delete" do
+        shipping_contact.delete
+
+        expect(shipping_contact.deleted).to eq(true)
+      end
+    end
+
+    context "updating shipping contacts" do
+      it "successful shipping contact update" do
+        shipping_contact.update(receiver: "Mario Moreno")
+
+        expect(shipping_contact.receiver).to eq("Mario Moreno")
+      end
+
+      it "unsuccessful shipping contact update" do
+        expect {
+          shipping_contact.update(receiver: 123)
+        }.to raise_error(Conekta::Error)
+      end
     end
   end
 end

--- a/spec/conekta/2.0.0/shipping_line_spec.rb
+++ b/spec/conekta/2.0.0/shipping_line_spec.rb
@@ -29,25 +29,57 @@ describe Conekta::ShippingLine do
 
   let(:shipping_line) { order.shipping_lines.first }
 
-  context "deleting shipping lines" do
-    it "successful shipping line delete" do
-      shipping_line.delete
+  context "with global api_key" do
+    context "deleting shipping lines" do
+      it "successful shipping line delete" do
+        shipping_line.delete
 
-      expect(shipping_line.deleted).to eq(true)
+        expect(shipping_line.deleted).to eq(true)
+      end
+    end
+
+    context "updating shipping lines" do
+      it "successful shipping line update" do
+        shipping_line.update(method: "Air")
+
+        expect(shipping_line._method).to eq("Air")
+      end
+
+      it "unsuccessful shipping line update" do
+        expect {
+          shipping_line.update(amount: -1)
+        }.to raise_error(Conekta::ParameterValidationError)
+      end
     end
   end
 
-  context "updating shipping lines" do
-    it "successful shipping line update" do
-      shipping_line.update(method: "Air")
+  context "with local api_key" do
+    include_context "local api_key"
 
-      expect(shipping_line._method).to eq("Air")
+    let(:order) do
+      Conekta::Order.create(order_data.merge(shipping_lines: shipping_lines), local_api_key)
     end
 
-    it "unsuccessful shipping line update" do
-      expect {
-        shipping_line.update(amount: -1)
-      }.to raise_error(Conekta::ParameterValidationError)
+    context "deleting shipping lines" do
+      it "successful shipping line delete" do
+        shipping_line.delete
+
+        expect(shipping_line.deleted).to eq(true)
+      end
+    end
+
+    context "updating shipping lines" do
+      it "successful shipping line update" do
+        shipping_line.update(method: "Air")
+
+        expect(shipping_line._method).to eq("Air")
+      end
+
+      it "unsuccessful shipping line update" do
+        expect {
+          shipping_line.update(amount: -1)
+        }.to raise_error(Conekta::ParameterValidationError)
+      end
     end
   end
 end

--- a/spec/conekta/2.0.0/source_spec.rb
+++ b/spec/conekta/2.0.0/source_spec.rb
@@ -7,25 +7,55 @@ describe Conekta::PaymentSource do
   let(:customer) { Conekta::Customer.create(customer_data) }
   let(:payment_source)   { customer.payment_sources.first }
 
-  context "deleting payment_sources" do
-    it "successful source delete" do
-      payment_source.delete
+  context "with global api_key" do
+    context "deleting payment_sources" do
+      it "successful source delete" do
+        payment_source.delete
 
-      expect(payment_source.deleted).to eq(true)
+        expect(payment_source.deleted).to eq(true)
+      end
+    end
+
+    context "updating payment_sources" do
+      it "successful payment_source update" do
+        payment_source.update(exp_month: 12)
+
+        expect(payment_source.exp_month).to eq("12")
+      end
+
+      it "unsuccessful payment_source update" do
+        expect {
+          payment_source.update(token_id: "tok_test_visa_4241")
+        }.to raise_error(Conekta::ParameterValidationError)
+      end
     end
   end
 
-  context "updating payment_sources" do
-    it "successful payment_source update" do
-      payment_source.update(exp_month: 12)
+  context "with local api_key" do
+    include_context "local api_key"
 
-      expect(payment_source.exp_month).to eq("12")
+    let(:customer) { Conekta::Customer.create(customer_data, local_api_key) }
+
+    context "deleting payment_sources" do
+      it "successful source delete" do
+        payment_source.delete
+
+        expect(payment_source.deleted).to eq(true)
+      end
     end
 
-    it "unsuccessful payment_source update" do
-      expect {
-        payment_source.update(token_id: "tok_test_visa_4241")
-      }.to raise_error(Conekta::ParameterValidationError)
+    context "updating payment_sources" do
+      it "successful payment_source update" do
+        payment_source.update(exp_month: 12)
+
+        expect(payment_source.exp_month).to eq("12")
+      end
+
+      it "unsuccessful payment_source update" do
+        expect {
+          payment_source.update(token_id: "tok_test_visa_4241")
+        }.to raise_error(Conekta::ParameterValidationError)
+      end
     end
   end
 end

--- a/spec/conekta/2.0.0/tax_line_spec.rb
+++ b/spec/conekta/2.0.0/tax_line_spec.rb
@@ -20,25 +20,55 @@ describe Conekta::TaxLine do
   let(:order)    { Conekta::Order.create(order_data.merge(tax_lines: tax_lines)) }
   let(:tax_line) { order.tax_lines.first }
 
-  context "deleting tax lines" do
-    it "successful tax line delete" do
-      tax_line.delete
+  context "with global api_key" do
+    context "deleting tax lines" do
+      it "successful tax line delete" do
+        tax_line.delete
 
-      expect(tax_line.deleted).to eq(true)
+        expect(tax_line.deleted).to eq(true)
+      end
+    end
+
+    context "updating tax lines" do
+      it "successful tax line update" do
+        tax_line.update(amount: 50)
+
+        expect(tax_line.amount).to eq(50)
+      end
+
+      it "unsuccessful tax line update" do
+        expect {
+          tax_line.update(amount: -1)
+        }.to raise_error(Conekta::Error)
+      end
     end
   end
 
-  context "updating tax lines" do
-    it "successful tax line update" do
-      tax_line.update(amount: 50)
+  context "with local api_key" do
+    include_context "local api_key"
 
-      expect(tax_line.amount).to eq(50)
+    let(:order)    { Conekta::Order.create(order_data.merge(tax_lines: tax_lines), local_api_key) }
+
+    context "deleting tax lines" do
+      it "successful tax line delete" do
+        tax_line.delete
+
+        expect(tax_line.deleted).to eq(true)
+      end
     end
 
-    it "unsuccessful tax line update" do
-      expect {
-        tax_line.update(amount: -1)
-      }.to raise_error(Conekta::Error)
+    context "updating tax lines" do
+      it "successful tax line update" do
+        tax_line.update(amount: 50)
+
+        expect(tax_line.amount).to eq(50)
+      end
+
+      it "unsuccessful tax line update" do
+        expect {
+          tax_line.update(amount: -1)
+        }.to raise_error(Conekta::Error)
+      end
     end
   end
 end

--- a/spec/conekta/2.0.0/transfer_spec.rb
+++ b/spec/conekta/2.0.0/transfer_spec.rb
@@ -28,32 +28,70 @@ describe Conekta::Payout do
     }
   end
 
-  describe 'an instance' do
-    before do
-      payee = Conekta::Payee.create(payee_attributes)
-      payout_method = payee.create_destination(bank_attributes)
+  context "with global api_key" do
+    describe 'an instance' do
+      before do
+        payee = Conekta::Payee.create(payee_attributes)
+        payout_method = payee.create_destination(bank_attributes)
 
-      @payee = Conekta::Payee.find(payee.id)
-    end
+        @payee = Conekta::Payee.find(payee.id)
+      end
 
-    it 'is created successfully' do
-      payout = Conekta::Transfer.create(
-        amount: 5000, currency: "MXN", payee: @payee.id
-      )
-      expect(payout).to be_a(Conekta::Transfer)
-    end
+      it 'is created successfully' do
+        payout = Conekta::Transfer.create(
+          amount: 5000, currency: "MXN", payee: @payee.id
+        )
+        expect(payout).to be_a(Conekta::Transfer)
+      end
 
-    it 'can be retrieved by :id' do
-      transaction = Conekta::Transfer.create(
-        amount: 5000, currency: "MXN", payee: @payee.id
-      )
-      # refetch payout
-      payout = Conekta::Transfer.find(transaction.id)
-      expect(payout).to be_a(Conekta::Transfer)
-    end
+      it 'can be retrieved by :id' do
+        transaction = Conekta::Transfer.create(
+          amount: 5000, currency: "MXN", payee: @payee.id
+        )
+        # refetch payout
+        payout = Conekta::Transfer.find(transaction.id)
+        expect(payout).to be_a(Conekta::Transfer)
+      end
 
-    it 'has a :method attribute' do
-      expect(@payee.destinations.first).to be_a(Conekta::Destination)
+      it 'has a :method attribute' do
+        expect(@payee.destinations.first).to be_a(Conekta::Destination)
+      end
     end
   end
+
+  context "with local api_key" do
+    include_context "local api_key"
+
+    describe 'an instance' do
+      before do
+        payee = Conekta::Payee.create(payee_attributes, local_api_key)
+        payout_method = payee.create_destination(bank_attributes)
+
+        @payee = Conekta::Payee.find(payee.id, local_api_key)
+      end
+
+      it 'is created successfully' do
+        payout = Conekta::Transfer.create(
+          {amount: 5000, currency: "MXN", payee: @payee.id},
+          local_api_key
+        )
+        expect(payout).to be_a(Conekta::Transfer)
+      end
+
+      it 'can be retrieved by :id' do
+        transaction = Conekta::Transfer.create(
+          {amount: 5000, currency: "MXN", payee: @payee.id},
+          local_api_key
+        )
+        # refetch payout
+        payout = Conekta::Transfer.find(transaction.id, local_api_key)
+        expect(payout).to be_a(Conekta::Transfer)
+      end
+
+      it 'has a :method attribute' do
+        expect(@payee.destinations.first).to be_a(Conekta::Destination)
+      end
+    end
+  end
+
 end

--- a/spec/support/shared_context.rb
+++ b/spec/support/shared_context.rb
@@ -47,3 +47,16 @@ shared_context "customer" do
     }
   end
 end
+
+shared_context "local api_key" do
+  let(:local_api_key) { 'key_ZLy4aP2szht1HqzkCezDEA' } # Can be another Sandbox key
+  let(:global_api_key) { 'key_ZLy4aP2szht1HqzkCezDEA' }
+
+  before(:all) do
+    Conekta.api_key = ""
+  end
+
+  after(:all) do
+    Conekta.api_key = global_api_key
+  end
+end


### PR DESCRIPTION
I believe that this is not the best approach in order to handle this, I thinks that we should be able to initialize a `Client` that has the proper accounts configs. 

Also I explore the idea about `Thread.current[]` for the configs, but this also brings another issues with webservers like Puma or Thin. I checked the gem [request_store](https://github.com/steveklabnik/request_store) to handle this situation, but also feel that it was a monkey patch.

I did not have the time to re-write the hole logic and also don't think that make sense. Maybe what makes more sense it's to write a thin API client instead of this **big hack**